### PR TITLE
Workaround for overflow error mentioned in issue #20

### DIFF
--- a/lapa/count.py
+++ b/lapa/count.py
@@ -169,8 +169,7 @@ class BaseCounter:
         return pr.PyRanges(df).count_overlaps(
             gr_bam,
             overlap_col='coverage',
-            strandedness='same',
-            nb_cpu = 8)
+            strandedness='same')
 
     def to_df(self):
         return self.to_gr().df.astype({'Chromosome': 'str', 'Strand': 'str'})

--- a/lapa/count.py
+++ b/lapa/count.py
@@ -8,6 +8,7 @@ import matplotlib.pyplot as plt
 from lapa.utils.io import bw_from_pyranges, \
     _read_talon_read_annot_five_prime_count, \
     _read_talon_read_annot_three_prime_count
+import numpy as np
 
 
 def _tqdm_counting(iterable):

--- a/lapa/count.py
+++ b/lapa/count.py
@@ -131,13 +131,9 @@ class BaseCounter:
         df_bam = pr.read_bam(self.bam_file, mapq=self.mapq, as_df=True)
         df_bam['Start'] -= 1
 
-        gr_bam = pr.PyRanges(df_bam)
-        gr_bam = gr_bam[gr_bam.Flag.isin({0, 16})]
-
-        gr = gr_bam.df
-        gr['Chromosome'] = gr['Chromosome'].astype(str)
+        df_bam['Chromosome'] = df_bam['Chromosome'].astype(str)
         df_counts = df.groupby(["Chromosome", "Strand"]).size().reset_index(name="Count")
-        gr_counts = gr.groupby(["Chromosome", "Strand"]).size().reset_index(name="Count")
+        gr_counts = df_bam.groupby(["Chromosome", "Strand"]).size().reset_index(name="Count")
         merged_counts = df_counts.merge(gr_counts, on=["Chromosome","Strand"], suffixes=("_df","_gr"))
         merged_counts["log2Prod"] = np.log2(merged_counts["Count_df"]) + np.log2(merged_counts["Count_gr"])
 
@@ -149,8 +145,8 @@ class BaseCounter:
                 num_division = 2**int(np.ceil(row['log2Prod']-31))
                 starts = list(df[(df['Chromosome'] == row['Chromosome']) & \
                                                 (df['Strand'] == row['Strand'])]['Start']) + \
-                                            list(gr[(gr['Chromosome'] == row['Chromosome']) & \
-                                                (gr['Strand'] == row['Strand'])]['Start'])
+                                            list(df_bam[(df_bam['Chromosome'] == row['Chromosome']) & \
+                                                (df_bam['Strand'] == row['Strand'])]['Start'])
                 percentiles = [np.percentile(starts, i*(100/num_division)) for i in range(1,num_division)]
                 percentiles = [np.percentile(starts, 0)] + percentiles + [np.percentile(starts, 100)]
                 for i in range(num_division):
@@ -159,18 +155,28 @@ class BaseCounter:
                     (df['Start'] >= percentiles[i]) & \
                     (df['Start'] <= percentiles[i+1])
                     df.loc[df_ind,'Chromosome'] = df[df_ind]['Chromosome'].apply(lambda x: str(x) + "$" + str(i))
-                    gr_ind = (gr['Chromosome'] == row['Chromosome']) & \
-                    (gr['Strand'] == row['Strand']) & \
-                    (gr['Start'] >= percentiles[i]) & \
-                    (gr['Start'] <= df.loc[df_ind,'End'].max())
-                    gr.loc[gr_ind,'Chromosome'] = gr[gr_ind]['Chromosome'].apply(lambda x: str(x) + "$" + str(i))
-        gr_bam = pr.PyRanges(gr)
-        
-        return pr.PyRanges(df).count_overlaps(
+                    gr_ind = (df_bam['Chromosome'] == row['Chromosome']) & \
+                    (df_bam['Strand'] == row['Strand']) & \
+                    (df_bam['Start'] >= percentiles[i]) & \
+                    (df_bam['Start'] <= df.loc[df_ind,'End'].max())
+                    df_bam.loc[gr_ind,'Chromosome'] = df_bam[gr_ind]['Chromosome'].apply(lambda x: str(x) + "$" + str(i))
+
+        gr_bam = pr.PyRanges(df_bam)
+        gr_bam = gr_bam[gr_bam.Flag.isin({0, 16})]
+
+
+        out =  pr.PyRanges(df).count_overlaps(
             gr_bam,
             overlap_col='coverage',
             strandedness='same')
+        
+        out2 = out.df
+        out2['Chromosome'] = out2['Chromosome'].astype(str)
+        out2['Chromosome'] = out2['Chromosome'].str.split('$').str[0]
 
+        return pr.PyRanges(out2)  
+
+    
     def to_df(self):
         return self.to_gr().df.astype({'Chromosome': 'str', 'Strand': 'str'})
 


### PR DESCRIPTION
If detected that the product of the sizes of df and gr_bam are over 2^31, will subset them both to avoid the overflow error. Will cause in a few lost edgecases near where the divisions are though. Now works on the cases where it failed due to this error.